### PR TITLE
Patch number is not part of OS X platfroms, so use Major.Minor versio…

### DIFF
--- a/src/main/java/org/jsoftbiz/utils/OS.java
+++ b/src/main/java/org/jsoftbiz/utils/OS.java
@@ -144,15 +144,15 @@ public class OS {
     if (numericVersion < 10)
       this.osInfo = new OsInfo(name, version, arch, "Mac OS " + version);
     else if(numericVersion < 10.12d)
-      this.osInfo = new OsInfo(name, version, arch, "OS X " + macOs.get(majorMinorVersion) + " (" + version + ")");
+      this.osInfo = new OsInfo(name, version, arch, "OS X " + macOs.get(majorMinorVersion) + " (" + majorMinorVersion + ")");
     else
-      this.osInfo = new OsInfo(name, version, arch, "macOS " + macOs.get(majorMinorVersion) + " (" + version + ")");
+      this.osInfo = new OsInfo(name, version, arch, "macOS " + macOs.get(majorMinorVersion) + " (" + majorMinorVersion + ")");
   }
 
   private void initDarwinOsInfo(final String name, final String version, final String arch) {
     String[] versions = version.split("\\.");
     int numericVersion = Integer.parseInt(versions[0]);
-    this.osInfo = new OsInfo(name, version, arch, "OS X " + darwin.get(numericVersion) + " (" + version + ")");
+    this.osInfo = new OsInfo(name, version, arch, "OS X " + darwin.get(numericVersion) + " (" + numericVersion + ")");
   }
 
   private void initLinuxOsInfo(final String name, final String version, final String arch) {


### PR DESCRIPTION
Patch number is not part of OS X platfroms, so use Major.Minor version in platform name of OS X platforms instead of full version number.

So instead of "OS X Yosemite (10.10.5)", the platform name is "OS X Yosemite (10.10)".
This will help to track platform names in graylogy easily via "quick values".